### PR TITLE
Update GMC Acadia generations: corrected production years from Wikipedia

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
-# Model make
+# GMC Acadia
 
+This repository contains signal set configurations for the GMC Acadia, organized by model year and version. The files are structured to allow for easy differentiation between model generations and other vehicle parameters, ensuring accurate signal mapping for each version of the GMC Acadia.
+
+## Contributing
+
+Contributions are welcome! If you would like to add support for additional model years or other configurations, please open an issue or submit a pull request.
+
+1. Fork the repository
+2. Create a new branch for your changes
+3. Commit your changes and open a pull request with a detailed description
+
+## Issues
+
+If you encounter any issues or would like to discuss improvements, please feel free to open an issue. We encourage collaboration and appreciate feedback to make the repository as accurate and useful as possible.

--- a/generations.yaml
+++ b/generations.yaml
@@ -1,3 +1,6 @@
+references:
+  - "https://en.wikipedia.org/wiki/GMC_Acadia"
+
 generations:
   - name: "First Generation"
     start_year: 2007
@@ -6,10 +9,10 @@ generations:
 
   - name: "Second Generation"
     start_year: 2017
-    end_year: 2022
+    end_year: 2023
     description: "The second-generation Acadia marked a significant change in positioning, downsizing from a full-size to a mid-size crossover. Built on GM's C1XX platform, it was approximately 7 inches shorter and 700 pounds lighter than its predecessor. Engine options expanded to include a 2.5L four-cylinder and a 3.6L V6, with a 2.0L turbocharged four-cylinder added in 2020. The interior maintained three-row seating but with reduced capacity for up to seven passengers, offering improved materials and technology including an 8-inch touchscreen infotainment system with Apple CarPlay and Android Auto compatibility. Special variants included the off-road-focused AT4 with enhanced capability features and the luxury Denali with premium appointments. A refresh in 2020 updated the exterior styling, transmission, and technology features. This generation repositioned the Acadia to compete in the highly competitive mid-size crossover segment, differentiating it more clearly from the larger Yukon in GMC's lineup."
 
   - name: "Third Generation"
-    start_year: 2023
+    start_year: 2024
     end_year: null
-    description: "The current Acadia returns to a larger size, though not as large as the original generation, positioning it more clearly in the three-row midsize SUV segment. Built on GM's VSS-S platform, it features more rugged, truck-inspired styling aligned with GMC's design language. Powered by a standard 2.0L turbocharged four-cylinder or an optional 3.6L V6 engine, paired with a nine-speed automatic transmission and available with front-wheel or all-wheel drive. The interior represents a significant advancement with higher quality materials, a standard 15-inch infotainment touchscreen, an 11-inch digital instrument cluster, and enhanced passenger space particularly in the third row. Seating configurations include six or seven-passenger arrangements depending on whether second-row captain's chairs are selected. Technology features include standard Super Cruise hands-free driving assistance, Google Built-in services, and comprehensive safety systems. The lineup continues to include the off-road AT4 and luxury Denali trims, with the latter featuring unique styling elements and premium appointments. This generation aims to better position the Acadia against three-row competitors like the Jeep Grand Cherokee L and Honda Pilot, offering enhanced capability and technology while maintaining GMC's professional grade identity."
+    description: "The current Acadia returns to a larger size, though not as large as the original generation, positioning it more clearly in the three-row midsize SUV segment. Built on GM's VSS-S platform (C1XX-2), it features more rugged, truck-inspired styling aligned with GMC's design language. Powered exclusively by a 2.5L turbocharged inline-four engine producing 328 HP and 326 lb-ft of torque, paired with an eight-speed automatic transmission and available with front-wheel or all-wheel drive. The interior represents a significant advancement with higher quality materials, a standard 15-inch infotainment touchscreen, an 11-inch digital instrument cluster, and enhanced passenger space particularly in the third row. Seating configurations include six or seven-passenger arrangements depending on whether second-row captain's chairs are selected. Technology features include standard Super Cruise hands-free driving assistance, Google Built-in services, and comprehensive safety systems. The lineup continues to include the off-road AT4 and luxury Denali trims, with the latter featuring unique styling elements and premium appointments. This generation aims to better position the Acadia against three-row competitors like the Jeep Grand Cherokee L and Honda Pilot, offering enhanced capability and technology while maintaining GMC's professional grade identity."


### PR DESCRIPTION
- Second Generation end_year updated to 2023 (Wikipedia: "production 2016–2023")
- Third Generation start_year updated to 2024 (Wikipedia: "production March 2024–present")
- Added references array with Wikipedia URL
- Updated Third Generation description to reflect accurate 2.5L turbo engine (not 2.0L/3.6L)
- Updated README.md with standard template

Evidence: Wikipedia infobox shows production dates for each generation
